### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Not all these things are mandatory for every talk, but considering them will mak
 
 ### Redistribution concerns
 
-* ☐ Do the slides make sense when seen without your talk? Or are some parts confusing without explanation and could lead to misunderstandings when distributed?
+* ☐ Can the slides be misread when viewed without context provided by the speaker? 
 * ☐ Is there an attribution for all media in the slide deck? Has any questionable, possibly copyrighted content been vetted? 
 * ☐ Is any third party content attributed to the correct author(s)?
 


### PR DESCRIPTION
Reworded one bullet under Redistribution concerns to be more specific about a slide potentially being misread when not having the speaker to explain. Previously it made it seem (to me anyway) that the slides must "stand on their own" which wasn't the intent.